### PR TITLE
Middleware & Authentication 예외 처리, JWT RefreshToken, Swagger 추가 및 response 양식 변경

### DIFF
--- a/applications/base/authentication.py
+++ b/applications/base/authentication.py
@@ -1,4 +1,5 @@
 from rest_framework.authentication import BaseAuthentication
+from rest_framework.exceptions import AuthenticationFailed
 
 from applications.base.jwt_utils import decode_jwt
 from applications.users.models import User
@@ -7,18 +8,18 @@ from applications.users.models import User
 class JsonWebTokenAuthentication(BaseAuthentication):
 
     def authenticate(self, request):
+        message = {"message": "INVALID_TOKEN"}
         access_token = request.headers.get("Authorization", None)
         if not access_token:
             return None
 
         auth_type, token = access_token.split(' ')
         payload = decode_jwt(token)
-        if auth_type == "Bearer":
-            user_id = payload.get("user_id", None)
-            try:
-                user = User.objects.get(id=user_id)
-                return user, None
-            except User.DoesNotExist:
-                return None
-        else:
-            return None
+
+        user_id = payload.get("user_id", None)
+        try:
+            user = User.objects.get(id=user_id)
+            return user, None
+        except User.DoesNotExist:
+            raise AuthenticationFailed(message)
+

--- a/applications/base/jwt_utils.py
+++ b/applications/base/jwt_utils.py
@@ -6,10 +6,7 @@ import jwt
 from django.conf import settings
 
 
-def generate_jwt(user_id):
-    """
-    jwt 신규 발급하는 함수입니다.
-    """
+def generate_access_jwt(user_id):
     iat = datetime.now()
     expired_date = iat + timedelta(weeks=2)
 
@@ -22,11 +19,32 @@ def generate_jwt(user_id):
     return jwt.encode(payload, settings.SECRET_KEY, 'HS256')
 
 
+def generate_refresh_jwt(user_id):
+    iat = datetime.now()
+    expired_date = iat + timedelta(weeks=4)
+
+    payload = {
+        "user_id": user_id,
+        "expired": expired_date.strftime("%Y-%m-%d %H:%M:%S"),
+        "iat": iat.timestamp(),
+    }
+
+    return jwt.encode(payload, settings.SECRET_KEY, 'HS256')
+
+
 def decode_jwt(token):
-    """
-    암호화 된 jwt 데이터를 복호화하는 함수입니다.
-    """
     try:
         return jwt.decode(token, settings.SECRET_KEY, 'HS256')
-    except Exception:
+    except:
         return None
+
+
+def check_jwt_expired_date(now_date, expired_date):
+    now_date = datetime.strptime(now_date, "%Y-%m-%d %H:%M:%S")
+    expired_date = datetime.strptime(expired_date, "%Y-%m-%d %H:%M:%S")
+
+    if expired_date <= now_date:
+        return True
+    else:
+        return False
+

--- a/applications/base/middleware.py
+++ b/applications/base/middleware.py
@@ -1,14 +1,10 @@
-# TODO : JWT 받고 난 이후 예외처리
-# 1. 토큰 없을 떄
-# 2. 토큰 만료됐을 때
-# 3. 이상한 토큰 왔을 때 (현재 저장되어 있지 않은 토큰일 때)
-# 4. 또 뭐있지
+from datetime import datetime
+
 from jwt import ExpiredSignatureError
 from rest_framework.exceptions import PermissionDenied
 
-from applications.base.jwt_utils import decode_jwt
+from applications.base.jwt_utils import decode_jwt, check_jwt_expired_date
 from applications.base.response import authorization_error, expired_token
-from applications.users.models import User
 
 
 class JsonWebTokenMiddleWare(object):
@@ -20,11 +16,11 @@ class JsonWebTokenMiddleWare(object):
         try:
             if (
                 request.path != "/v1/users/auth/kakao"
+                and request.path != "/v1/refresh_token"
                 and "admin" not in request.path
                 and "swagger" not in request.path
             ):
                 access_token = request.headers.get("Authorization", None)
-
                 if not access_token:
                     raise PermissionDenied()
 
@@ -33,6 +29,12 @@ class JsonWebTokenMiddleWare(object):
                     payload = decode_jwt(token)
                     if not payload:
                         raise PermissionDenied("permission denied")
+
+                    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                    token_expired = payload.get('expired')
+
+                    if check_jwt_expired_date(now, token_expired):
+                        raise ExpiredSignatureError()
 
                     user_id = payload.get("user_id", None)
                     if not user_id:

--- a/applications/base/response.py
+++ b/applications/base/response.py
@@ -6,8 +6,10 @@ operation_success = Response(status=status.HTTP_200_OK, data={"message": "OPERAT
 operation_failure = Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "OPERATION_FAILURE"})
 
 delete_success = Response(status=status.HTTP_204_NO_CONTENT, data={"message": "DELETE_SUCCESS"})
+
 not_found_data = Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "NOT_FOUND_DATA"})
 invalid_date_range = Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "INVALID_DATE_RANGE"})
+same_data_failure = Response(status=status.HTTP_400_BAD_REQUEST, data={"message": "SAME_DATA_FAILURE"})
 certification_failure = Response(status=status.HTTP_401_UNAUTHORIZED, data={'message': 'CERTIFICATION_FAILURE'})
 permission_error = Response(status=status.HTTP_403_FORBIDDEN, data={'message': 'PERMISSION_ERROR'})
 

--- a/applications/base/swaggers.py
+++ b/applications/base/swaggers.py
@@ -37,3 +37,9 @@ dispatch_settlement_body = openapi.Schema(
     },
     required=['member', 'amount'],
 )
+
+
+authorizaion_parameters = openapi.Parameter(
+    'Authorization', openapi.IN_HEADER,
+    description="accesstoken은 필수입니다.",
+    type=openapi.TYPE_STRING, required=True)

--- a/applications/billings/views.py
+++ b/applications/billings/views.py
@@ -18,7 +18,11 @@ from applications.billings.serializers import BillingSerializer
 @api_view(['GET'])
 def get_currencies(request):
     # todo: 섹시한 메서드 있으면 변경
-    return Response({'message': [choice[0] for choice in CurrencyType.CHOICES]}, status=status.HTTP_200_OK)
+    data_response = {
+        "message": "OPERATION_SUCCESS",
+        "results": [choice[0] for choice in CurrencyType.CHOICES]
+    }
+    return Response(data_response)
 
 
 class BillingViewSet(mixins.RetrieveModelMixin,

--- a/applications/billings/views.py
+++ b/applications/billings/views.py
@@ -1,17 +1,20 @@
 from djmoney.money import Money
-from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import mixins, status
 from rest_framework.decorators import action, api_view
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
-from applications.base.swaggers import dispatch_settlement_body
+from applications.base.swaggers import dispatch_settlement_body, authorizaion_parameters
 from applications.billings import SettlementStatus, CurrencyType
 from applications.billings.models import Billing, Settlement
 from applications.billings.serializers import BillingSerializer
 
 
+@swagger_auto_schema(
+    method='get',
+    operation_summary="전체 화폐 리스트 조회 API",
+)
 @api_view(['GET'])
 def get_currencies(request):
     # todo: 섹시한 메서드 있으면 변경
@@ -34,8 +37,7 @@ class BillingViewSet(mixins.RetrieveModelMixin,
     @swagger_auto_schema(
         operation_summary="billing 상세 API",
         manual_parameters=[
-            openapi.Parameter('Authorized', openapi.IN_HEADER, description="accesstoken이 없으면 이용 못합니다.",
-                              type=openapi.TYPE_STRING, required=True),
+            authorizaion_parameters
         ]
     )
     def retrieve(self, request, *args, **kwargs):
@@ -44,8 +46,7 @@ class BillingViewSet(mixins.RetrieveModelMixin,
     @swagger_auto_schema(
         operation_summary="billing 삭제 API",
         manual_parameters=[
-            openapi.Parameter('Authorized', openapi.IN_HEADER, description="accesstoken이 없으면 이용 못합니다.",
-                              type=openapi.TYPE_STRING, required=True),
+            authorizaion_parameters
         ],
     )
     def destroy(self, request, *args, **kwargs):
@@ -54,8 +55,7 @@ class BillingViewSet(mixins.RetrieveModelMixin,
     @swagger_auto_schema(
         operation_summary="billing 수정 API",
         manual_parameters=[
-            openapi.Parameter('Authorized', openapi.IN_HEADER, description="accesstoken이 없으면 이용 못합니다.",
-                              type=openapi.TYPE_STRING, required=True),
+            authorizaion_parameters
         ],
     )
     def update(self, request, *args, **kwargs):
@@ -64,8 +64,7 @@ class BillingViewSet(mixins.RetrieveModelMixin,
     @swagger_auto_schema(
         operation_summary="billing 생성 API",
         manual_parameters=[
-            openapi.Parameter('Authorized', openapi.IN_HEADER, description="accesstoken이 없으면 이용 못합니다.",
-                              type=openapi.TYPE_STRING, required=True),
+            authorizaion_parameters
         ],
         request_body=dispatch_settlement_body,
     )

--- a/applications/travels/views.py
+++ b/applications/travels/views.py
@@ -37,7 +37,11 @@ class TravelViewSet(mixins.CreateModelMixin,
     )
     def list(self, request, *args, **kwargs):
         serializer = self.get_serializer(self.queryset, many=True)
-        return Response(serializer.data)
+        data_response = {
+            "message": "OPERATION_SUCCESS",
+            "results": serializer.data
+        }
+        return Response(data_response)
 
     @swagger_auto_schema(
         operation_summary="여행 생성 API",
@@ -69,7 +73,11 @@ class TravelViewSet(mixins.CreateModelMixin,
             serializer = self.serializer_class(data=request.data, context={"request": request})
             if serializer.is_valid():
                 serializer.save()
-                return Response(serializer.data)
+                results = {
+                    "message": "OPERATION_SUCCESS",
+                    "results": serializer.data
+                }
+                return Response(results)
             else:
                 return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         else:
@@ -86,7 +94,11 @@ class TravelViewSet(mixins.CreateModelMixin,
         if not travel:
             return not_found_data
         travel_data = self.serializer_class(travel, context={'request': request}).data
-        return Response(travel_data)
+        data_response = {
+            "message": "OPERATION_SUCCESS",
+            "results": travel_data
+        }
+        return Response(data_response)
 
     @swagger_auto_schema(
         operation_summary="여행 수정 API",
@@ -113,9 +125,13 @@ class TravelViewSet(mixins.CreateModelMixin,
         serializer = self.serializer_class(travel, data=request.data, partial=True)
         if serializer.is_valid():
             updated_travel = serializer.save()
-            return Response(self.serializer_class(updated_travel).data)
+            results = {
+                "message": "OPERATION_SUCCESS",
+                "results": self.serializer_class(updated_travel).data
+            }
+            return Response(results)
         else:
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return operation_failure
 
     @swagger_auto_schema(
         operation_summary="여행 삭제 탈퇴",

--- a/applications/travels/views.py
+++ b/applications/travels/views.py
@@ -7,7 +7,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from applications.base.response import operation_failure, not_found_data, delete_success, permission_error, \
     invalid_date_range
-from applications.base.swaggers import billing_create_api_body
+from applications.base.swaggers import billing_create_api_body, authorizaion_parameters
 from applications.billings.serializers import BillingSerializer
 from applications.travels.models import Travel
 from applications.travels.serializers import TravelSerializer
@@ -22,22 +22,40 @@ class TravelViewSet(mixins.CreateModelMixin,
     queryset = Travel.objects.all()
     serializer_class = TravelSerializer
 
-    @swagger_auto_schema(
-        operation_summary="여행 전체 리스트 API",
-        request_body=no_body,
-    )
     def get_object(self, pk):
         try:
             return Travel.objects.get(id=pk)
         except Travel.DoesNotExist:
             return None
 
+    @swagger_auto_schema(
+        operation_summary="여행 전체 리스트 API",
+        manual_parameters=[
+            authorizaion_parameters
+        ],
+        request_body=no_body,
+    )
     def list(self, request, *args, **kwargs):
-        return super().list(request, *args, **kwargs)
+        serializer = self.get_serializer(self.queryset, many=True)
+        return Response(serializer.data)
 
     @swagger_auto_schema(
         operation_summary="여행 생성 API",
-        request_body=no_body,
+        manual_parameters=[
+            authorizaion_parameters
+        ],
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                'title': openapi.Schema(type=openapi.TYPE_INTEGER),
+                'start_date': openapi.Schema(type=openapi.FORMAT_DATE),
+                'end_date': openapi.Schema(type=openapi.FORMAT_DATE),
+                'color': openapi.Schema(type=openapi.TYPE_STRING),
+                'description': openapi.Schema(type=openapi.TYPE_STRING),
+                'currency': openapi.Schema(type=openapi.TYPE_STRING),
+            },
+            required=['title', 'color', 'currency', 'start_date', 'end_date'],
+        ),
     )
     def create(self, request, *args, **kwargs):
         data = request.data.copy()
@@ -59,7 +77,9 @@ class TravelViewSet(mixins.CreateModelMixin,
 
     @swagger_auto_schema(
         operation_summary="여행 상세 API",
-        request_body=no_body,
+        manual_parameters=[
+            authorizaion_parameters
+        ],
     )
     def retrieve(self, request, pk, *args, **kwargs):
         travel = self.get_object(pk)
@@ -70,7 +90,20 @@ class TravelViewSet(mixins.CreateModelMixin,
 
     @swagger_auto_schema(
         operation_summary="여행 수정 API",
-        request_body=no_body,
+        manual_parameters=[
+            authorizaion_parameters
+        ],
+        request_body=openapi.Schema(
+            type=openapi.TYPE_OBJECT,
+            properties={
+                'title': openapi.Schema(type=openapi.TYPE_INTEGER),
+                'start_date': openapi.Schema(type=openapi.FORMAT_DATE),
+                'end_date': openapi.Schema(type=openapi.FORMAT_DATE),
+                'color': openapi.Schema(type=openapi.TYPE_STRING),
+                'description': openapi.Schema(type=openapi.TYPE_STRING),
+                'currency': openapi.Schema(type=openapi.TYPE_STRING),
+            },
+        ),
     )
     def update(self, request, pk):
         travel = self.get_object(pk)
@@ -86,7 +119,9 @@ class TravelViewSet(mixins.CreateModelMixin,
 
     @swagger_auto_schema(
         operation_summary="여행 삭제 탈퇴",
-        request_body=no_body,
+        manual_parameters=[
+            authorizaion_parameters
+        ],
     )
     def destroy(self, request, pk, *args, **kwargs):
         travel = self.get_object(pk)
@@ -102,8 +137,7 @@ class TravelViewSet(mixins.CreateModelMixin,
     @swagger_auto_schema(
         operation_summary="billing 생성 API",
         manual_parameters=[
-            openapi.Parameter('Authorized', openapi.IN_HEADER, description="accesstoken이 없으면 이용 못합니다.",
-                              type=openapi.TYPE_STRING, required=True),
+            authorizaion_parameters
         ],
         request_body=billing_create_api_body,
     )

--- a/applications/users/serializers.py
+++ b/applications/users/serializers.py
@@ -1,3 +1,4 @@
+from django.utils import dateformat
 from rest_framework import serializers
 
 from applications.users.models import User
@@ -5,8 +6,11 @@ from applications.users.models import User
 
 class UserSerializer(serializers.ModelSerializer):
     nickname = serializers.CharField(required=False)
-    social_id = serializers.CharField(required=False)
+    created = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = User
-        fields = ('nickname', 'fcm_token', 'social_id')
+        fields = ('nickname', 'fcm_token', 'created')
+
+    def get_created(self, obj):
+        return dateformat.format(obj.created, 'Y-m-d')

--- a/applications/users/utils.py
+++ b/applications/users/utils.py
@@ -1,5 +1,7 @@
 import requests
 
+from applications.base.jwt_utils import decode_jwt, generate_access_jwt, generate_refresh_jwt
+
 
 def kakao_get_user_info(access_token):
     """
@@ -21,4 +23,24 @@ def kakao_get_user_info(access_token):
         kakao_info = {"id": kakao_id, "nickname": nickname}
         return kakao_info
     except:
+        return None
+
+
+def token_equality_check(access_token, refresh_token):
+    access_token_payload = decode_jwt(access_token)
+    refresh_token_payload = decode_jwt(refresh_token)
+
+    if access_token_payload and refresh_token_payload:
+        access_token_user_id = access_token_payload.get("user_id", None)
+        refresh_token_user_id = refresh_token_payload.get("user_id", None)
+
+        if access_token_user_id == refresh_token_user_id:
+            new_access_token = generate_access_jwt(access_token_user_id)
+            new_refresh_token = generate_refresh_jwt(refresh_token_user_id)
+
+            results = {"token": new_access_token, "refresh_token": new_refresh_token}
+            return results
+        else:
+            return None
+    else:
         return None

--- a/applications/users/views.py
+++ b/applications/users/views.py
@@ -69,7 +69,6 @@ class UserViewSet(mixins.RetrieveModelMixin,
             "message": message,
             "results": results
         }
-
         return Response(data_response, status=status_code)
 
     def get_object(self, pk):
@@ -90,7 +89,11 @@ class UserViewSet(mixins.RetrieveModelMixin,
             return not_found_data
 
         user_data = self.serializer_class(user).data
-        return Response(user_data)
+        results = {
+            "message": "OPERATION_SUCCESS",
+            "results": user_data
+        }
+        return Response(results)
 
     @swagger_auto_schema(
         operation_summary="유저 수정 API",
@@ -116,7 +119,11 @@ class UserViewSet(mixins.RetrieveModelMixin,
         serializer = self.serializer_class(user, data=request.data, partial=True)
         if serializer.is_valid():
             updated_travel = serializer.save()
-            return Response(self.serializer_class(updated_travel).data)
+            results = {
+                "message": "OPERATION_SUCCESS",
+                "results": self.serializer_class(updated_travel).data
+            }
+            return Response(results)
         else:
             return operation_failure
 
@@ -166,7 +173,7 @@ def jwt_refresh_token(request):
         return certification_failure
 
     data_response = {
-        "message": "operation_success",
+        "message": "OPERATION_SUCCESS",
         "results": results
     }
     return Response(data_response)

--- a/config/urls.py
+++ b/config/urls.py
@@ -25,7 +25,7 @@ from rest_framework.routers import SimpleRouter
 
 from applications.billings.views import BillingViewSet, get_currencies
 from applications.travels.views import TravelViewSet
-from applications.users.views import UserViewSet
+from applications.users.views import UserViewSet, jwt_refresh_token
 
 schema_view = get_schema_view(
     openapi.Info(
@@ -49,8 +49,10 @@ router.register('v1/billings', BillingViewSet, 'billings')
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('v1/currencies/', get_currencies),
     path('', include(router.urls)),
+
+    path('v1/currencies', get_currencies),
+    path('v1/refresh_token', jwt_refresh_token),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
1. MiddleWare 토큰 만료 예외 처리 추가
2. Authentication Uesr 없을 때 예외 처리 추가
3. Swagger 누락된 부분 추가
4. jwt refresh token API 생성 및 카카오 로그인 API도 수정
5. response 양식 변경 (Users, Travels) + get_currencies
```py
"message": "OPERATION_SUCCESS",
"results": {

}
```